### PR TITLE
feat: add tooltip

### DIFF
--- a/Assets/Resources/UI/Tooltip.uxml
+++ b/Assets/Resources/UI/Tooltip.uxml
@@ -1,0 +1,9 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <ui:VisualElement name="Tooltip__bg" style="background-color: rgba(22, 22, 31, 0.5); min-width: 50px; min-height: 50px; width: auto; height: auto; max-width: initial; max-height: initial; flex-direction: row; flex-basis: auto; align-items: center; justify-content: flex-start; position: absolute; top: auto;">
+        <ui:IMGUIContainer name="Tooltip__icon" style="width: 45px; height: 45px; margin-left: 2px; margin-top: 2px; background-color: rgba(17, 26, 34, 0.7); justify-content: flex-start; align-items: stretch;" />
+        <ui:VisualElement name="Texts" style="margin-left: 5px; width: 100%; margin-right: 5px; margin-top: 5px; margin-bottom: 5px; justify-content: space-between;">
+            <ui:Label text="Label" display-tooltip-when-elided="true" name="Main__text" style="-unity-font-style: bold; color: rgb(255, 255, 255); margin-left: 0; margin-right: 0; margin-top: 0; margin-bottom: 0; padding-left: 0; padding-right: 0; padding-top: 0; padding-bottom: 0; font-size: 20px;" />
+            <ui:Label text="Labelrezarezarezarezarezarzearezrezraerezarezarzaerazeraze" display-tooltip-when-elided="true" name="Secondary__text" enable-rich-text="true" style="-unity-font-style: normal; color: rgb(161, 173, 180); margin-left: 0; margin-right: 0; margin-top: 0; margin-bottom: 0; padding-left: 0; padding-right: 0; padding-top: 0; padding-bottom: 0; font-size: 16px; max-width: 400px; flex-wrap: wrap; white-space: normal;" />
+        </ui:VisualElement>
+    </ui:VisualElement>
+</ui:UXML>

--- a/Assets/Resources/UI/Tooltip.uxml.meta
+++ b/Assets/Resources/UI/Tooltip.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 85ca6c35ed9ffc441a32759ef8a1ef94
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -553,6 +553,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _uiDocument: {fileID: 1593146515}
+  _ability: {fileID: 11400000, guid: a52bbbc4aea05f9499886c7aaf8d828c, type: 2}
   _phaseManager: {fileID: 1363686106}
   _mouseController: {fileID: 129747757}
 --- !u!1 &682458436
@@ -2058,7 +2059,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   phaseState: 0
-  _uiManager: {fileID: 0}
   _uiController: {fileID: 528675438}
   _mouseController: {fileID: 129747757}
   _characterSpawner: {fileID: 160786582}

--- a/Assets/Scriptable Object/Abilities/Arrows rain.asset
+++ b/Assets/Scriptable Object/Abilities/Arrows rain.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a100121a54dad7d488aa2e1e787d0042, type: 3}
   m_Name: Arrows rain
   m_EditorClassIdentifier: 
+  icon: {fileID: 21300000, guid: bb51334c6930f864abac38001f7bdf6e, type: 3}
   name: "Pluie de fl\xE8ches"
   description: "Inflige x2 d\xE9g\xE2ts \xE0 tous les ennemis dans la zone."
   efficiencyMultiplicator: 2

--- a/Assets/Scriptable Object/Maps/DemoBattle.asset
+++ b/Assets/Scriptable Object/Maps/DemoBattle.asset
@@ -18,6 +18,6 @@ MonoBehaviour:
   - {x: -5, y: 4, z: 1}
   - {x: -6, y: 3, z: 1}
   ennemiesSpawnPos:
-  - {x: 3, y: 0, z: 1}
+  - {x: -4, y: 3, z: 1}
   ennemies:
   - {fileID: 409437123900460136, guid: 9b271bf5533b5804a85ecbf762e2373b, type: 3}

--- a/Assets/Scripts/SO/AbilitySO.cs
+++ b/Assets/Scripts/SO/AbilitySO.cs
@@ -20,6 +20,7 @@ namespace BattleSystem.SO
 
     public class AbilitySO : ScriptableObject
     {
+        public Sprite icon;
         public new string name;
         public string description;
         public float efficiencyMultiplicator;

--- a/Assets/Scripts/UI/Tooltip.cs
+++ b/Assets/Scripts/UI/Tooltip.cs
@@ -1,0 +1,115 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+public class Tooltip
+{
+    private VisualElement _root;
+
+    private bool _isActive;
+
+    #region Elements
+    private VisualElement _bg;
+    private IMGUIContainer _icon;
+    private Label _title;
+    private Label _description;
+    #endregion
+
+    #region Element settings
+    private int _width;
+    private int _height;
+    private Vector2Int _offset;
+    #endregion
+
+    public Tooltip(VisualElement root, int width = 400, int height = 85)
+    {
+        _isActive = false;
+
+        _root = root;
+        _width = width;
+        _height = height;
+        SetOffset(0, 75);
+    }
+
+    public void SetOffset(int x, int y)
+    {
+        _offset = new Vector2Int(x, y);
+    }
+
+    private void SetBackground(Vector2 mousePosition)
+    {
+        float leftPosition = mousePosition.x - _offset.x;
+        float topPosition = mousePosition.y - _offset.y;
+
+        _bg.style.position = Position.Absolute;
+
+        if (leftPosition + _width > Screen.width) leftPosition = mousePosition.x - _width;
+        else if (leftPosition - _width < 0) leftPosition = 0;
+        _bg.style.left = leftPosition;
+
+        if (topPosition + _height > Screen.height) topPosition = mousePosition.y - _height;
+        else if (topPosition - _height < 0) topPosition = 0;
+        _bg.style.top = topPosition;
+
+        _bg.style.width = _width;
+        _bg.style.height = _height;
+
+        _bg.MarkDirtyRepaint();
+    }
+
+    public void ShowTooltip(Vector2 position, string title, string description = "", Sprite icon = null)
+    {
+        if (_isActive) return;
+
+        VisualTreeAsset vt = Resources.Load<VisualTreeAsset>("UI/Tooltip");
+        _bg = vt.Instantiate();
+
+        SetBackground(position);
+
+        _icon = _bg.Q<IMGUIContainer>("Tooltip__icon");
+        _title = _bg.Q<Label>("Main__text");
+        _description = _bg.Q<Label>("Secondary__text");
+
+        if (icon == null)
+        {
+            _icon.style.display = DisplayStyle.None;
+        }
+        else
+        {
+            _icon.style.backgroundImage = new StyleBackground(icon);
+        }
+
+        if (description == "")
+        {
+            _description.style.display = DisplayStyle.None;
+        }
+        else
+        {
+            _description.text = description;
+        }
+
+        _title.text = title;
+
+        _root.Add(_bg);
+        _isActive = true;
+    }
+
+    /// <summary>
+    /// Adapte la taille du tooltip par rapport au texte
+    /// </summary>
+    public void AutoSizeTooltip()
+    {
+        _bg.style.width = StyleKeyword.Auto;
+        _bg.style.height = StyleKeyword.Auto;
+        _width = (int)Mathf.Round(_bg.style.width.value.value);
+        _height = (int)Mathf.Round(_bg.style.height.value.value);
+    }
+    public void HideTooltip()
+    {
+        if (!_isActive) return;
+
+        _root.Remove(_bg);
+        _isActive = false;
+    }
+}

--- a/Assets/Scripts/UI/Tooltip.cs.meta
+++ b/Assets/Scripts/UI/Tooltip.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f592ced6428c5342a83ae4e46510f8d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/UnitPanel.cs
+++ b/Assets/Scripts/UI/UnitPanel.cs
@@ -11,6 +11,7 @@ namespace BattleSystem.UI
     public class UnitPanel : MonoBehaviour
     {
         public UIDocument hud;
+        private Tooltip _tooltip;
 
         #region heathBar
         private HealthBar _healthBar;
@@ -30,15 +31,36 @@ namespace BattleSystem.UI
         private Label _range;
         private Label _atkRange;
         #endregion
+
+        #region Groupboxs
+        private GroupBox _atkGroup;
+        private GroupBox _rangeGroup;
+        private GroupBox _atkRangeGroup;
+        #endregion
+
+
         void Start()
         {
             var root = hud.rootVisualElement;
+            _tooltip = new Tooltip(root);
 
             _healthBar = root.Q<HealthBar>();
 
             _name = root.Q<Label>("Character__name");
 
             _icon = root.Q<IMGUIContainer>("Character__img");
+
+            _atkGroup = root.Q<GroupBox>("Character__Atk");
+            _atkGroup.RegisterCallback<MouseEnterEvent, string>(DisplayTooltip, "Attaque");
+            _atkGroup.RegisterCallback<MouseLeaveEvent>(HideTooltip);
+
+            _rangeGroup = root.Q<GroupBox>("Character__Range");
+            _rangeGroup.RegisterCallback<MouseEnterEvent, string>(DisplayTooltip, "Portée");
+            _rangeGroup.RegisterCallback<MouseLeaveEvent>(HideTooltip);
+
+            _atkRangeGroup = root.Q<GroupBox>("Character__AtkRange");
+            _atkRangeGroup.RegisterCallback<MouseEnterEvent, string>(DisplayTooltip, "Portée d'attaque");
+            _atkRangeGroup.RegisterCallback<MouseLeaveEvent>(HideTooltip);
 
             _atk = root.Q<Label>("Atk__value");
             _range = root.Q<Label>("Range__value");
@@ -78,6 +100,7 @@ namespace BattleSystem.UI
             }
         }
 
+        #region setters
         public void SetMaxHealth(int health)
         {
             _maxHealth = health;
@@ -114,6 +137,22 @@ namespace BattleSystem.UI
         {
             _atkRange.text = atkRange.ToString();
         }
+        #endregion
 
+        #region Tooltip handler
+        private void DisplayTooltip(MouseEnterEvent evt, string message)
+        {
+            Vector2 mousePosition = evt.mousePosition;
+
+            _tooltip.SetOffset(0, 55);
+            _tooltip.ShowTooltip(mousePosition, message);
+            _tooltip.AutoSizeTooltip();
+        }
+
+        private void HideTooltip(MouseLeaveEvent evt)
+        {
+            _tooltip.HideTooltip();
+        }
+        #endregion
     }
 }

--- a/Assets/Scripts/UIController.cs
+++ b/Assets/Scripts/UIController.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using BattleSystem.SO;
 using UnityEngine;
 using UnityEngine.UIElements;
-using UnityEngine.UIElements.Experimental;
 
 namespace BattleSystem
 {
@@ -44,11 +44,14 @@ namespace BattleSystem
 
         private VisualElement _root;
 
+        private Tooltip _tooltip;
+
         void Awake()
         {
             LeanTween.init(1000);
 
             _root = _uiDocument.rootVisualElement;
+            _tooltip = new Tooltip(_root);
 
             _prepPhaseWindow = _root.Q<VisualElement>("Phase__prep");
             _playerPhaseWindow = _root.Q<VisualElement>("Phase__player");
@@ -81,6 +84,8 @@ namespace BattleSystem
 
             _skillBtn = _root.Q<Button>("Action__skills");
             _skillBtn.RegisterCallback<ClickEvent, string>(UseSkill, "");
+            _skillBtn.RegisterCallback<MouseEnterEvent>(ShowSkillTooltip);
+            _skillBtn.RegisterCallback<MouseLeaveEvent>(HideSkillTooltip);
 
             _switchModeBtn = _root.Q<Button>("Action__switchMode");
             _switchModeBtn.RegisterCallback<ClickEvent, string>(SwitchMode, "");
@@ -88,6 +93,8 @@ namespace BattleSystem
             _endTurnBtn = _root.Q<Button>("Action__endTurn");
             _endTurnBtn.RegisterCallback<ClickEvent, string>(EndTurn, "");
         }
+
+
         #endregion
 
         private void StartGame(ClickEvent evt, string args)
@@ -220,5 +227,18 @@ namespace BattleSystem
         }
         #endregion
 
+        #region button hovered handlers
+        private void ShowSkillTooltip(MouseEnterEvent evt)
+        {
+            Vector2 mousePosition = evt.mousePosition;
+            AbilitySO playerAbility = _mouseController.character.GetStats().skill;
+            _tooltip.ShowTooltip(mousePosition, playerAbility.name, playerAbility.description, playerAbility.icon);
+        }
+
+        private void HideSkillTooltip(MouseLeaveEvent evt)
+        {
+            _tooltip.HideTooltip();
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
Ajout de `Tooltip.cs` qui permet de créer une petite box dynamique au survol d'un élément.

Les éléments survolables sont :
- Bouton compétence
- Les statistiques en bas à gauche du personnage.

Il est possible que ce commit contiennent d'autres informations de changement (dû à nos changements d'hier).